### PR TITLE
Bump Docker version to 20.10.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM docker:17.12.0-ce-dind
+FROM docker:20.10.6-dind
 
 # coreutils so we have the real dd, not the busybox one
-RUN apk update && apk add --no-cache python3 parted btrfs-progs util-linux sfdisk file coreutils sgdisk
+RUN apk update && apk add --no-cache py3-pip parted btrfs-progs util-linux sfdisk file coreutils sgdisk
 
 COPY ./requirements.txt /tmp/
 


### PR DESCRIPTION
Docker 20.10 supports cgroup v2 and works on Fedora by default.

Change-type: patch
Changelog-entry: Bump Docker version to 20.10.6
Signed-off-by: Kyle Harding <kyle@balena.io>

See these posts relating to the support for cgroups v2 in Docker:
- https://www.docker.com/blog/introducing-docker-engine-20-10/
- https://medium.com/nttlabs/cgroup-v2-596d035be4d7

Resolves:
- https://github.com/balena-io/balena-cli/issues/2250

I first reproduced the issue with a Fedora 33 VM.
- installing Docker v19 would not even run `hello-world`
- installing Docker v20 was able to run `hello-world`
- running `balena-preload` would fail to start the Docker-in-Docker container
- bumping the dind version from v17 to v20 allowed Docker-in-Docker to run