### PR TITLE
Avoid hardcoded registry2 URL

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,14 +3,6 @@
 # See http://editorconfig.org
 root = true
 
-[*]
-end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
-indent_style = space
-indent_size = 2
-charset = utf-8
-
 [*.py]
 indent_style = space
 indent_size = 4

--- a/.resinci.yml
+++ b/.resinci.yml
@@ -1,3 +1,11 @@
 ---
 docker:
   publish: false
+npm:
+  platforms:
+    - name: linux
+      os: ubuntu
+      architecture: x86_64
+      node_versions:
+        - "10"
+        - "12"

--- a/lib/preload.js
+++ b/lib/preload.js
@@ -514,7 +514,8 @@ class Preloader extends EventEmitter {
 		// List images from the release.
 		const images = this._getRelease().contains__image.map((ci) => {
 			return _.merge({}, ci.image[0], {
-				is_stored_at__image_location: ci.image[0].is_stored_at__image_location.toLowerCase(),
+				is_stored_at__image_location:
+					ci.image[0].is_stored_at__image_location.toLowerCase(),
 			});
 		});
 		// App from the state endpoint (v1 or v2 depending on the supervisor version).
@@ -551,6 +552,7 @@ class Preloader extends EventEmitter {
 	}
 
 	async registry(
+		registryUrl,
 		endpoint,
 		registryToken,
 		headers,
@@ -561,7 +563,7 @@ class Preloader extends EventEmitter {
 		headers = { ...headers };
 		headers['Authorization'] = `Bearer ${registryToken}`;
 		return await request({
-			url: `https://${this.balenaSettings.registry2Url}${endpoint}`,
+			url: `https://${registryUrl}${endpoint}`,
 			headers: headers,
 			json: decodeJson,
 			simple: false,
@@ -571,7 +573,7 @@ class Preloader extends EventEmitter {
 		});
 	}
 
-	async _getLayerSize(token, layerUrl) {
+	async _getLayerSize(token, registryUrl, layerUrl) {
 		// This gets an approximation of the layer size because:
 		// * it is the size of the tar file, not the size of the contents of the tar file (the tar file is slightly larger);
 		// * the gzip footer only gives the size % 32 so it will be incorrect for layers larger than 4GiB
@@ -580,6 +582,7 @@ class Preloader extends EventEmitter {
 		// We don't want to send the registry token to s3 so we ask it to not follow
 		// redirects and issue the second request manually.
 		let response = await this.registry(
+			registryUrl,
 			layerUrl,
 			token,
 			headers,
@@ -603,6 +606,12 @@ class Preloader extends EventEmitter {
 			);
 		}
 		return response.body.readUIntLE(0, 4);
+	}
+
+	_registryUrl(imageLocation) {
+		// imageLocation: registry2.balena-cloud.com/v2/ad7cd3616b4e72ed51a5ad349e03715e@sha256:4c042f195b59b7d4c492e210ab29ab61694f490a69c65720a5a0121c6277ecdd
+		const slashIndex = imageLocation.search('/');
+		return `${imageLocation.substring(0, slashIndex)}`;
 	}
 
 	_imageManifestUrl(imageLocation) {
@@ -633,6 +642,7 @@ class Preloader extends EventEmitter {
 			imagesLocations,
 			async (imageLocation) => {
 				const { body: manifest } = await this.registry(
+					this._registryUrl(imageLocation),
 					this._imageManifestUrl(imageLocation),
 					registryToken,
 					{},
@@ -662,6 +672,7 @@ class Preloader extends EventEmitter {
 			async ({ imageLocation, layer }) => {
 				const size = await this._getLayerSize(
 					registryToken,
+					this._registryUrl(imageLocation),
 					this._layerUrl(imageLocation, layer.digest),
 				);
 				layersSizes.set(layer.digest, { size, compressedSize: layer.size });
@@ -734,7 +745,7 @@ class Preloader extends EventEmitter {
 				baseUrl: this.balena.pine.API_URL,
 				url: '/auth/v1/token',
 				qs: {
-					service: this.balenaSettings.registry2Url,
+					service: this._registryUrl(images[0]),
 					scope: images.map(
 						(imageRepository) =>
 							`repository:${imageRepository.substr(

--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
     "url": "https://github.com/balena-io/balena-preload/issues"
   },
   "scripts": {
-    "lint": "balena-lint -e js --typescript lib",
-    "lint-fix": "balena-lint -e js --typescript --fix lib",
+    "lint": "balena-lint -e js --typescript --fix lib",
     "lint-python": "flake8 src/preload.py",
     "test": "npm run lint",
     "prepare": "tsc"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/node": "^10.17.28",
     "@types/tmp": "0.0.34",
     "@types/unzipper": "^0.8.4",
+    "catch-uncommitted": "^2.0.0",
     "typescript": "^3.9.7"
   },
   "peerDependencies": {
@@ -60,7 +61,7 @@
   "scripts": {
     "lint": "balena-lint -e js --typescript --fix lib",
     "lint-python": "flake8 src/preload.py",
-    "test": "npm run lint",
+    "test": "npm run lint && catch-uncommitted --skip-node-versionbot-changes",
     "prepare": "tsc"
   },
   "bin": {


### PR DESCRIPTION
Instead we can extract the registry URL from the image location
as we do for the manifest and layer endpoints.

Resolves: https://github.com/balena-io-modules/balena-preload/issues/236
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>