### PR TITLE
Support new storage-driver location in balena.service

### DIFF
--- a/src/preload.py
+++ b/src/preload.py
@@ -882,6 +882,8 @@ def get_docker_storage_driver(docker_service_file_contents):
             position = find_one_of(words, "-s", "--storage-driver")
             if position != -1 and position < len(words) - 1:
                 return words[position + 1]
+        if line.startswith("Environment=BALENAD_STORAGEDRIVER="):
+            return line.split('=')[-1]
     assert False, "Docker storage driver could not be found"
 
 


### PR DESCRIPTION
Starting in balenaOS v2.80.9 the balena.service file was
refactored and the storage-driver is defined by an environment
variable.

Resolves: https://github.com/balena-io-modules/balena-preload/issues/248
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>