### PR TITLE
Catch errors during build of preload image

### DIFF
--- a/lib/preload.js
+++ b/lib/preload.js
@@ -276,8 +276,11 @@ class Preloader extends EventEmitter {
 		await new Bluebird((resolve, reject) => {
 			this.docker.modem.followProgress(
 				build,
-				(error) => {
+				(error, output) => {
 					// onFinished
+					if (!error && output) {
+						error = output.pop().error;
+					}
 					if (error) {
 						reject(error);
 					} else {


### PR DESCRIPTION
Try to catch errors such as https://github.com/balena-io/balena-cli/issues/2290

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>