### PR TITLE
Avoid TypeError if build output array is empty

### DIFF
--- a/lib/preload.js
+++ b/lib/preload.js
@@ -277,7 +277,7 @@ class Preloader extends EventEmitter {
 				build,
 				(error, output) => {
 					// onFinished
-					if (!error && output) {
+					if (!error && output && output.length) {
 						error = output.pop().error;
 					}
 					if (error) {


### PR DESCRIPTION
Extends: https://github.com/balena-io-modules/balena-preload/pull/257
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>