### PR TITLE
Stop relying on the /device-types/v1 endpoints

### DIFF
--- a/lib/preload.ts
+++ b/lib/preload.ts
@@ -21,7 +21,14 @@ import * as compareVersions from 'compare-versions';
 import * as request from 'request-promise';
 import { promisify } from 'util';
 import getFolderSize = require('get-folder-size');
-import { Application, PineFilter, Release } from 'balena-sdk';
+import type {
+	Application,
+	BalenaSDK,
+	DeviceType,
+	PineDeferred,
+	PineFilter,
+	Release,
+} from 'balena-sdk';
 import { DirOptions } from 'tmp';
 const getFolderSizeAsync: (arg1: string) => Promise<number> =
 	promisify(getFolderSize);
@@ -155,6 +162,16 @@ type Image = {
 	image_size: number;
 };
 
+interface ImageInfo {
+	preloaded_builds: string[];
+	supervisor_version: string;
+	free_space: number;
+	config: {
+		deviceType: string;
+	};
+	balena_os_version: string;
+}
+
 const createContainer = async (
 	docker: Docker,
 	image: string,
@@ -264,13 +281,13 @@ export class Preloader extends EventEmitter {
 	container;
 	tmpCleanup;
 	state; // device state from the api
-	freeSpace; // space available on the image data partition (in bytes)
-	preloadedBuilds; // list of preloaded Docker images in the disk image
-	supervisorVersion; // disk image supervisor version
-	balenaOSVersion; // OS version from the image's "/etc/issue" file
-	config; // config.json data from the disk image
-	deviceTypes;
-	balena;
+	freeSpace: number | undefined; // space available on the image data partition (in bytes)
+	preloadedBuilds: string[] | undefined; // list of preloaded Docker images in the disk image
+	supervisorVersion: string | undefined; // disk image supervisor version
+	balenaOSVersion: string | undefined; // OS version from the image's "/etc/issue" file
+	config: ImageInfo['config'] | undefined; // config.json data from the disk image
+	deviceTypes: DeviceType[] | undefined;
+	balena: BalenaSDK;
 	docker;
 	appId;
 	commit;
@@ -521,6 +538,7 @@ export class Preloader extends EventEmitter {
 		});
 		const { body: state } = await this.balena.request.send({
 			headers: { 'User-Agent': SUPERVISOR_USER_AGENT },
+			// @ts-expect-error
 			baseUrl: this.balena.pine.API_URL,
 			url: `device/v${this._supervisorLT7() ? 1 : 2}/${uuid}/state`,
 		});
@@ -531,13 +549,7 @@ export class Preloader extends EventEmitter {
 	async _getImageInfo() {
 		// returns Promise<object> (device_type, preloaded_builds, free_space and config)
 		await this._runWithSpinner('Reading image information', async () => {
-			const info = (await this._runCommand('get_image_info', {})) as {
-				preloaded_builds: string;
-				supervisor_version: string;
-				free_space: string;
-				config: string;
-				balena_os_version: string;
-			};
+			const info = (await this._runCommand('get_image_info', {})) as ImageInfo;
 			this.freeSpace = info.free_space;
 			this.preloadedBuilds = info.preloaded_builds;
 			this.supervisorVersion = info.supervisor_version;
@@ -790,12 +802,12 @@ export class Preloader extends EventEmitter {
 			return this.additionalSpace;
 		}
 		const size = Math.round((await this._getSize()) * 1.4);
-		return Math.max(0, size - this.freeSpace);
+		return Math.max(0, size - this.freeSpace!);
 	}
 
 	_supervisorLT7() {
 		try {
-			return compareVersions(this.supervisorVersion, '7.0.0') === -1;
+			return compareVersions(this.supervisorVersion!, '7.0.0') === -1;
 		} catch (e) {
 			// Suppose the supervisor version is >= 7.0.0 when it is not valid semver.
 			return false;
@@ -805,6 +817,7 @@ export class Preloader extends EventEmitter {
 	_getRegistryToken(images) {
 		return Bluebird.resolve(
 			this.balena.request.send({
+				// @ts-expect-error
 				baseUrl: this.balena.pine.API_URL,
 				url: '/auth/v1/token',
 				qs: {
@@ -833,12 +846,13 @@ export class Preloader extends EventEmitter {
 					status: 'success',
 				};
 				if (this.commit === 'latest') {
-					const {
-						should_be_running__release: { __id },
-					} = await this.balena.models.application.get(this.appId, {
-						$select: 'should_be_running__release',
-					});
-					releaseFilter.id = __id;
+					const { should_be_running__release } =
+						await this.balena.models.application.get(this.appId, {
+							$select: 'should_be_running__release',
+						});
+					// TODO: Add a check to error if the application is not tracking any release
+					releaseFilter.id =
+						(should_be_running__release as PineDeferred | null)!.__id;
 				} else if (this.commit != null) {
 					releaseFilter.commit = { $startswith: this.commit };
 				}
@@ -1018,7 +1032,7 @@ export class Preloader extends EventEmitter {
 
 		// Don't preload if the image arch does not match the application arch
 		if (this.dontCheckArch === false) {
-			const imageArch = this._deviceTypeArch(this.config.deviceType);
+			const imageArch = this._deviceTypeArch(this.config!.deviceType);
 			const applicationArch =
 				this.application.is_for__device_type[0].is_of__cpu_architecture[0].slug;
 			if (
@@ -1076,7 +1090,7 @@ export class Preloader extends EventEmitter {
 	 */
 	_getSplashImagePath() {
 		try {
-			if (compareVersions(this.balenaOSVersion, '2.53.0') >= 0) {
+			if (compareVersions(this.balenaOSVersion!, '2.53.0') >= 0) {
 				return '/splash/balena-logo.png';
 			}
 		} catch (err) {
@@ -1174,7 +1188,6 @@ preload.CONTAINER_NAME = 'balena-image-preloader';
 preload.applicationExpandOptions = {
 	owns__release: {
 		$select: ['id', 'commit', 'end_timestamp', 'composition'],
-		$orderby: [{ end_timestamp: 'desc' }, { id: 'desc' }],
 		$expand: {
 			contains__image: {
 				$select: ['image'],
@@ -1188,5 +1201,6 @@ preload.applicationExpandOptions = {
 		$filter: {
 			status: 'success',
 		},
+		$orderby: [{ end_timestamp: 'desc' }, { id: 'desc' }],
 	},
 };

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "scripts": {
     "lint": "balena-lint --fix lib",
     "lint-python": "flake8 src/preload.py",
-    "test": "npm run lint && catch-uncommitted --skip-node-versionbot-changes",
+    "test": "tsc --noEmit && npm run lint && catch-uncommitted --skip-node-versionbot-changes",
     "prepare": "tsc"
   },
   "versionist": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/tar-fs": "^2.0.1",
     "@types/unzipper": "^0.8.4",
     "catch-uncommitted": "^2.0.0",
-    "typescript": "^4.3.5"
+    "typescript": "^4.5.5"
   },
   "homepage": "https://github.com/balena-io/balena-preload",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "archiver": "^3.1.1",
-    "balena-sdk": "^15.44.0",
+    "balena-sdk": "^16.0.0",
     "bluebird": "^3.7.2",
     "compare-versions": "^3.6.0",
     "docker-progress": "^5.0.0",


### PR DESCRIPTION
Also bumps balena-sdk to v16 (which bumps the node dependency) and TypeScript to v4.5.

Resolves: #269
Change-type: major
See: https://jel.ly.fish/improvement-stop-relying-device-types-v1-device-type-json-unrelated-things-4fbac3c
See: https://jel.ly.fish/brainstorm-topic-cc53b047-fbee-4778-b664-fa7322e9abf4
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>
