### PR TITLE
Fix stdin regression with docker

### DIFF
--- a/lib/preload.ts
+++ b/lib/preload.ts
@@ -1038,6 +1038,7 @@ export class Preloader extends EventEmitter {
 				stdout: true,
 				stderr: true,
 				stdin: true,
+				hijack: true
 			});
 			this.stdin = stream;
 			this.docker.modem.demuxStream(stream, this.stdout, this.stderr);

--- a/src/preload.py
+++ b/src/preload.py
@@ -975,6 +975,8 @@ if __name__ == "__main__":
         try:
             data = json.loads(line)
             method = methods[data["command"]]
+            log.info("Running '%s'", method.__name__)
+            log.debug("with kwargs: '%s'", data.get("parameters", {}))
             result = method(**data.get("parameters", {}))
             response = {
                 "result": result,


### PR DESCRIPTION
On my machine running Docker Desktop for ARM Mac 4.11.1 (84025), running `balena preload` gets stuck at `Reading image information`.

```
% balena preload …
| Checking that the image is a writable file
| Finding a free tcp port
| Checking if the image is an edison zip archive
/ Creating preloader container
| Starting preloader container
- Fetching application USER/APP
- Reading image information
```

The cause is that the container never receives data on `stdin`, so `preload.py` remains idle.

Speculation suggests that this broke with Docker Desktop 4.10.0 based on moby/moby#43799. I've also submitted an upstream PR to apocas/docker-modem#148 to make the change in this PR the default, but I'm submitting this PR in hopes to resolve the issue for balena users faster.

For future refactors, I suggest adding additional logging in `preload.py` that's more helpful than what I've contributed in this PR.