### PR TITLE
minor: build for every major node version >=12

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "author": "Balena Ltd (https://balena.io)",
   "engines": {
-    "node": "12"
+    "node": ">=12"
   },
   "keywords": [
     "balena",


### PR DESCRIPTION
As node 12 is deprecated and in order to build the CLI on node 14+ 