### PR TITLE
Update resin-cli-visuals to 1.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node-cleanup": "^2.1.2",
     "request": "^2.88.2",
     "request-promise": "^4.2.6",
-    "resin-cli-visuals": "^1.8.0",
+    "resin-cli-visuals": "^1.8.1",
     "tar-fs": "^2.1.1",
     "tmp-promise": "^3.0.2",
     "unzipper": "^0.8.14"


### PR DESCRIPTION
The new package updates etcher-sdk so it no longer depends on our node-usb fork.

Change-type: patch
Relates-to: balena-io-modules/resin-cli-visuals#71