### PR TITLE
Add Write Permission to File to Allow truncate() Operation to Succeed

### DIFF
--- a/src/preload.py
+++ b/src/preload.py
@@ -518,7 +518,7 @@ def expand_filesystem(partition):
 
 
 def expand_file(path, additional_bytes):
-    with open(path, "a") as f:
+    with open(path, "a+") as f:
         size = f.tell()
         f.truncate(size + additional_bytes)
 


### PR DESCRIPTION
I got the following error and am proposing this change to remediate.

Status code: 1
Error: Traceback (most recent call last):
  File "/usr/src/app/preload.py", line 978, in <module>
    result = method(**data.get("parameters", {}))
  File "/usr/src/app/preload.py", line 923, in main_preload
    preload(additional_bytes, app_data, splash_image_path)
  File "/usr/src/app/preload.py", line 713, in preload
    part.resize(additional_bytes)
  File "/usr/src/app/preload.py", line 434, in resize
    self._resize_last_partition_of_disk_image(additional_bytes)
  File "/usr/src/app/preload.py", line 334, in _resize_last_partition_of_disk_image
    expand_file(self.image, additional_bytes)
  File "/usr/src/app/preload.py", line 523, in expand_file
    f.truncate(size + additional_bytes)
PermissionError: [Errno 13] Permission denied