### PR TITLE
MAJOR: Update `balena-sdk` to v21

### DIFF
--- a/lib/preload.ts
+++ b/lib/preload.ts
@@ -152,7 +152,7 @@ export const applicationExpandOptions = {
 	owns__release: {
 		$select: ['id', 'commit', 'end_timestamp', 'composition'],
 		$expand: {
-			contains__image: {
+			release_image: {
 				$select: ['image'],
 				$expand: {
 					image: {
@@ -570,10 +570,10 @@ export class Preloader extends EventEmitter {
 		// This method lists the images that need to be preloaded.
 		// The is_stored_at__image_location attribute must match the image attribute of the app or app service in the state endpoint.
 		// List images from the release.
-		const images = this._getRelease().contains__image.map((ci) => {
-			return _.merge({}, ci.image[0], {
+		const images = this._getRelease().release_image.map((ri) => {
+			return _.merge({}, ri.image[0], {
 				is_stored_at__image_location:
-					ci.image[0].is_stored_at__image_location.toLowerCase(),
+					ri.image[0].is_stored_at__image_location.toLowerCase(),
 			});
 		});
 
@@ -894,7 +894,7 @@ export class Preloader extends EventEmitter {
 					owns__release: {
 						$select: ['id', 'commit', 'end_timestamp', 'composition'],
 						$expand: {
-							contains__image: {
+							release_image: {
 								$select: ['image'],
 								$expand: {
 									image: {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "requirements.txt"
   ],
   "dependencies": {
-    "balena-sdk": "^20.1.3",
+    "balena-sdk": "^21.2.0",
     "compare-versions": "^3.6.0",
     "docker-progress": "^5.0.0",
     "dockerode": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "build/preload.js",
   "types": "build/preload.d.ts",
   "engines": {
-    "node": ">=18"
+    "node": "^20.12.0 || >=22.0.0"
   },
   "keywords": [
     "balena",
@@ -23,7 +23,7 @@
     "requirements.txt"
   ],
   "dependencies": {
-    "balena-sdk": "^21.2.0",
+    "balena-sdk": "^20.1.3",
     "compare-versions": "^3.6.0",
     "docker-progress": "^5.0.0",
     "dockerode": "^4.0.2",
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@balena/lint": "^7.2.6",
     "@types/dockerode": "^3.3.23",
-    "@types/node": "^18.0.0",
+    "@types/node": "^20.17.22",
     "@types/request-promise": "^4.1.48",
     "@types/tar-fs": "^2.0.1",
     "catch-uncommitted": "^2.0.0",


### PR DESCRIPTION
Required for: https://github.com/balena-io/balena-cli/pull/2921
Fibery (for CLI PR): https://balena.fibery.io/Work/Project/Default-API-key-expiry-860