### PR TITLE
Add id-token: write permission for NPM OIDC publishing

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -7,6 +7,11 @@ on:
       - "main"
       - "master"
 
+permissions:
+  id-token: write
+  contents: read
+  packages: read
+
 jobs:
   flowzone:
     name: Flowzone

--- a/package.json
+++ b/package.json
@@ -41,13 +41,13 @@
     "catch-uncommitted": "^2.0.0",
     "typescript": "^5.6.2"
   },
-  "homepage": "https://github.com/balena-io/balena-preload",
+  "homepage": "https://github.com/balena-io-modules/balena-preload",
   "repository": {
     "type": "git",
-    "url": "https://github.com/balena-io/balena-preload.git"
+    "url": "https://github.com/balena-io-modules/balena-preload.git"
   },
   "bugs": {
-    "url": "https://github.com/balena-io/balena-preload/issues"
+    "url": "https://github.com/balena-io-modules/balena-preload/issues"
   },
   "scripts": {
     "lint": "balena-lint --fix lib",


### PR DESCRIPTION
Add `id-token: write` permission to enable NPM publishing via OIDC trusted publishers.
Include `contents: read` and `packages: read` to preserve org default permissions.

Connects-to: https://balena.fibery.io/Work/Improvement/3782

Change-type: patch