### PR TITLE
Move to ESM, drop support for nodejs < 24.11.0 & update TypeScript to 6.0.2

### DIFF
--- a/lib/preload.ts
+++ b/lib/preload.ts
@@ -1,14 +1,14 @@
-import * as _ from 'lodash';
-import * as EventEmitter from 'events';
-import * as dockerProgress from 'docker-progress';
-import * as Docker from 'dockerode';
-import * as path from 'path';
-import * as streamModule from 'stream';
-import * as tarfs from 'tar-fs';
+import _ from 'lodash';
+import EventEmitter from 'events';
+import dockerProgress from 'docker-progress';
+import Docker from 'dockerode';
+import path from 'path';
+import streamModule from 'stream';
+import tarfs from 'tar-fs';
 import { promises as fs, constants } from 'fs';
-import * as getPort from 'get-port';
-import * as os from 'os';
-import * as compareVersions from 'compare-versions';
+import getPort from 'get-port';
+import os from 'os';
+import compareVersions from 'compare-versions';
 import type {
 	Application,
 	BalenaSDK,

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "Apache-2.0",
   "author": "Balena Ltd (https://balena.io)",
   "main": "build/preload.js",
+  "type": "module",
   "types": "build/preload.d.ts",
   "engines": {
     "node": "^24.11.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "build/preload.js",
   "types": "build/preload.d.ts",
   "engines": {
-    "node": "^22.18.0 || >= 24.0.0"
+    "node": "^24.11.0"
   },
   "keywords": [
     "balena",
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@balena/lint": "^7.2.6",
     "@types/dockerode": "^3.3.23",
-    "@types/node": "^20.17.22",
+    "@types/node": "^24.12.2",
     "@types/request-promise": "^4.1.48",
     "@types/tar-fs": "^2.0.1",
     "catch-uncommitted": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/request-promise": "^4.1.48",
     "@types/tar-fs": "^2.0.1",
     "catch-uncommitted": "^2.0.0",
-    "typescript": "^5.6.2"
+    "typescript": "^6.0.2"
   },
   "homepage": "https://github.com/balena-io-modules/balena-preload",
   "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-		"module": "commonjs",
+		"module": "node16",
 		"declaration": true,
 		"target": "es2019",
 		"outDir": "build",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,18 +3,15 @@
 		"module": "node16",
 		"declaration": true,
 		"target": "es2019",
+		"rootDir": "./lib",
 		"outDir": "build",
-		"strict": true,
 		"noImplicitAny": false,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		"preserveConstEnums": true,
 		"removeComments": true,
 		"sourceMap": true,
 		"skipLibCheck": true,
-		"preserveSymlinks": true,
-		"allowJs": true,
-		"checkJs": true
+		"preserveSymlinks": true
 	},
 	"include": [
 		"./lib/**/*",


### PR DESCRIPTION
Change-type: major
See: https://balena.fibery.io/Work/Project/2389